### PR TITLE
[Oztechan/CCC#3309] Enable Crashlytics only in release mode

### DIFF
--- a/android/app/src/main/kotlin/com/oztechan/ccc/android/app/Application.kt
+++ b/android/app/src/main/kotlin/com/oztechan/ccc/android/app/Application.kt
@@ -10,8 +10,8 @@ import android.os.StrictMode.ThreadPolicy
 import android.os.StrictMode.VmPolicy
 import co.touchlab.kermit.Logger
 import com.github.submob.logmob.ANRWatchDogHandler
-import com.github.submob.logmob.initCrashlytics
 import com.github.submob.logmob.initLogger
+import com.github.submob.logmob.setCrashlyticsCollection
 import com.oztechan.ccc.android.app.di.initKoin
 import com.oztechan.ccc.android.core.ad.initAds
 import com.oztechan.ccc.client.core.analytics.initAnalytics
@@ -21,8 +21,9 @@ class Application : Application() {
     override fun onCreate() {
         super.onCreate()
 
+        setCrashlyticsCollection(!BuildConfig.DEBUG)
+
         if (!BuildConfig.DEBUG) {
-            initCrashlytics()
             initAnalytics(this)
         }
 


### PR DESCRIPTION
Resolves Oztechan/CCC#3309
<!--
Pull Request Checklist
1. I have read the https://github.com/Oztechan/CCC/blob/develop/docs/CONTRIBUTING.md
2. PR title is in the format of `[Oztechan/CCC#ISSUE_ID] ISSUE_TITLE`
3. I have added a valid description and pictures if necessary.
4. I replaced `ISSUE_ID` with the ID of issue.
5. I have tested the app before creating this PR 
-->
