### PR TITLE
[Oztechan/CCC#4854] Koin graph verification tests (backend first)

### DIFF
--- a/backend/app/backend-app.gradle.kts
+++ b/backend/app/backend-app.gradle.kts
@@ -1,7 +1,16 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 plugins {
     libs.plugins.apply {
         application
         alias(kotlinJvm)
+    }
+}
+
+tasks.withType<Test> {
+    testLogging {
+        exceptionFormat = TestExceptionFormat.FULL
+        events("failed")
     }
 }
 

--- a/backend/app/backend-app.gradle.kts
+++ b/backend/app/backend-app.gradle.kts
@@ -65,6 +65,8 @@ dependencies {
     libs.jvm.apply {
         testImplementation(test)
         testImplementation(koinTest)
+        // Brings ktor-client-core so the graph test can name HttpClientEngine for verify's extraTypes.
+        testImplementation(ktor)
     }
 }
 

--- a/backend/app/backend-app.gradle.kts
+++ b/backend/app/backend-app.gradle.kts
@@ -52,6 +52,11 @@ dependencies {
     Modules.Common.DataSource.apply {
         implementation(project(conversion))
     }
+
+    libs.jvm.apply {
+        testImplementation(test)
+        testImplementation(koinTest)
+    }
 }
 
 tasks.withType<Jar> {

--- a/backend/app/src/test/kotlin/com/oztechan/ccc/backend/app/KoinGraphTest.kt
+++ b/backend/app/src/test/kotlin/com/oztechan/ccc/backend/app/KoinGraphTest.kt
@@ -17,16 +17,19 @@ internal class KoinGraphTest {
     @OptIn(KoinExperimentalAPI::class)
     @Test
     fun `backend Koin graph has all dependencies declared`() {
-        module {
-            includes(
-                backendServicePremiumModule,
-                backendControllerSyncModule,
-                backendControllerAPIModule,
-                commonCoreDatabaseModule,
-                commonCoreNetworkModule,
-                commonCoreInfrastructureModule,
-                commonDataSourceConversionModule
-            )
-        }.verify()
+        // DIAGNOSTIC: surface the exact missing type in the CI log, then set extraTypes accordingly.
+        runCatching {
+            module {
+                includes(
+                    backendServicePremiumModule,
+                    backendControllerSyncModule,
+                    backendControllerAPIModule,
+                    commonCoreDatabaseModule,
+                    commonCoreNetworkModule,
+                    commonCoreInfrastructureModule,
+                    commonDataSourceConversionModule
+                )
+            }.verify()
+        }.exceptionOrNull()?.let { error("KOIN_VERIFY_MESSAGE >>> ${it.message}") }
     }
 }

--- a/backend/app/src/test/kotlin/com/oztechan/ccc/backend/app/KoinGraphTest.kt
+++ b/backend/app/src/test/kotlin/com/oztechan/ccc/backend/app/KoinGraphTest.kt
@@ -7,6 +7,7 @@ import com.oztechan.ccc.common.core.database.di.commonCoreDatabaseModule
 import com.oztechan.ccc.common.core.infrastructure.di.commonCoreInfrastructureModule
 import com.oztechan.ccc.common.core.network.di.commonCoreNetworkModule
 import com.oztechan.ccc.common.datasource.conversion.di.commonDataSourceConversionModule
+import io.ktor.client.engine.HttpClientEngine
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.dsl.module
 import org.koin.test.verify.verify
@@ -27,6 +28,9 @@ internal class KoinGraphTest {
                 commonCoreInfrastructureModule,
                 commonDataSourceConversionModule
             )
-        }.verify()
+        }.verify(
+            // Ktor picks the HttpClientEngine implicitly at runtime, so it has no Koin binding.
+            extraTypes = listOf(HttpClientEngine::class)
+        )
     }
 }

--- a/backend/app/src/test/kotlin/com/oztechan/ccc/backend/app/KoinGraphTest.kt
+++ b/backend/app/src/test/kotlin/com/oztechan/ccc/backend/app/KoinGraphTest.kt
@@ -1,0 +1,32 @@
+package com.oztechan.ccc.backend.app
+
+import com.oztechan.ccc.backend.controller.api.di.backendControllerAPIModule
+import com.oztechan.ccc.backend.controller.sync.di.backendControllerSyncModule
+import com.oztechan.ccc.backend.service.premium.di.backendServicePremiumModule
+import com.oztechan.ccc.common.core.database.di.commonCoreDatabaseModule
+import com.oztechan.ccc.common.core.infrastructure.di.commonCoreInfrastructureModule
+import com.oztechan.ccc.common.core.network.di.commonCoreNetworkModule
+import com.oztechan.ccc.common.datasource.conversion.di.commonDataSourceConversionModule
+import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.dsl.module
+import org.koin.test.verify.verify
+import kotlin.test.Test
+
+internal class KoinGraphTest {
+
+    @OptIn(KoinExperimentalAPI::class)
+    @Test
+    fun `backend Koin graph has all dependencies declared`() {
+        module {
+            includes(
+                backendServicePremiumModule,
+                backendControllerSyncModule,
+                backendControllerAPIModule,
+                commonCoreDatabaseModule,
+                commonCoreNetworkModule,
+                commonCoreInfrastructureModule,
+                commonDataSourceConversionModule
+            )
+        }.verify()
+    }
+}

--- a/backend/app/src/test/kotlin/com/oztechan/ccc/backend/app/KoinGraphTest.kt
+++ b/backend/app/src/test/kotlin/com/oztechan/ccc/backend/app/KoinGraphTest.kt
@@ -17,19 +17,16 @@ internal class KoinGraphTest {
     @OptIn(KoinExperimentalAPI::class)
     @Test
     fun `backend Koin graph has all dependencies declared`() {
-        // DIAGNOSTIC: surface the exact missing type in the CI log, then set extraTypes accordingly.
-        runCatching {
-            module {
-                includes(
-                    backendServicePremiumModule,
-                    backendControllerSyncModule,
-                    backendControllerAPIModule,
-                    commonCoreDatabaseModule,
-                    commonCoreNetworkModule,
-                    commonCoreInfrastructureModule,
-                    commonDataSourceConversionModule
-                )
-            }.verify()
-        }.exceptionOrNull()?.let { error("KOIN_VERIFY_MESSAGE >>> ${it.message}") }
+        module {
+            includes(
+                backendServicePremiumModule,
+                backendControllerSyncModule,
+                backendControllerAPIModule,
+                commonCoreDatabaseModule,
+                commonCoreNetworkModule,
+                commonCoreInfrastructureModule,
+                commonDataSourceConversionModule
+            )
+        }.verify()
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -103,6 +103,7 @@ ios-sqlliteDriver = { module = "com.squareup.sqldelight:native-driver", version.
 
 # JVM
 jvm-test = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+jvm-koinTest = { module = "io.insert-koin:koin-test", version.ref = "koinCore" }
 jvm-ktor = { module = "io.ktor:ktor-client-apache", version.ref = "ktor" }
 jvm-koinKtor = { module = "io.insert-koin:koin-ktor", version.ref = "koinKtor" }
 jvm-sqlliteDriver = { module = "com.squareup.sqldelight:sqlite-driver", version.ref = "sqlDelight" }


### PR DESCRIPTION
Closes #4854 (backend part first).

## What
Adds a Koin **graph verification** test that composes the assembled backend + common modules and calls koin-test's `verify()`, so a missing/broken binding fails the build instead of at app launch.

Chose whole-graph `verify()` over ~30 per-module tests because the `backend/app` module already aggregates every module `val` — no new cross-module exports needed.

- `jvm-koinTest` (`io.insert-koin:koin-test`) added to the version catalog.
- `backend/app`: `testImplementation(test, koinTest)` + `KoinGraphTest`.

## Draft — needs CI
I could not run this locally: the CCC Gradle build fails at configuration on my machine with an AGP `AnalyticsService` / `kotlinx-coroutines` `NoSuchMethodError` (a toolchain issue unrelated to this change — a sibling project on the same machine builds fine). Opening as **draft** so CI, which has the right toolchain, validates it.

If `verify()` reports missing external types, they get added via `extraTypes = listOf(...)` — I'll iterate on the CI result.

## Next (once green on CI)
- `android/app`: Robolectric `verify()` over the client + common + android graph.
- iOS (`ios/provider`) assembles the graph with iOS-only types on Kotlin/Native, where reflection-based `verify()` isn't available — out of scope for JVM unit tests (noted in the issue).
