### PR TITLE
[Oztechan/CCC#4856] Koin graph verification test for the Android app graph

### DIFF
--- a/android/app/android-app.gradle.kts
+++ b/android/app/android-app.gradle.kts
@@ -158,4 +158,11 @@ dependencies {
         implementation(project(mobile))
         implementation(project(widget))
     }
+
+    libs.jvm.apply {
+        testImplementation(test)
+        testImplementation(koinTest)
+        // Brings ktor-client-core so the graph test can name HttpClientEngine for verify's extraTypes.
+        testImplementation(ktor)
+    }
 }

--- a/android/app/src/test/kotlin/com/oztechan/ccc/android/app/AndroidKoinGraphTest.kt
+++ b/android/app/src/test/kotlin/com/oztechan/ccc/android/app/AndroidKoinGraphTest.kt
@@ -1,0 +1,83 @@
+package com.oztechan.ccc.android.app
+
+import android.content.Context
+import com.oztechan.ccc.android.core.ad.di.androidCoreAdModule
+import com.oztechan.ccc.android.core.billing.di.androidCoreBillingModule
+import com.oztechan.ccc.android.viewmodel.widget.di.androidViewModelWidgetModule
+import com.oztechan.ccc.client.configservice.ad.di.clientConfigServiceAdModule
+import com.oztechan.ccc.client.configservice.review.di.clientConfigServiceReviewModel
+import com.oztechan.ccc.client.configservice.update.di.clientConfigServiceUpdateModule
+import com.oztechan.ccc.client.core.analytics.di.clientCoreAnalyticsModule
+import com.oztechan.ccc.client.core.persistence.di.clientCorePersistenceModule
+import com.oztechan.ccc.client.core.shared.Device
+import com.oztechan.ccc.client.datasource.currency.di.clientDataSourceCurrencyModule
+import com.oztechan.ccc.client.datasource.watcher.di.clientDataSourceWatcherModule
+import com.oztechan.ccc.client.repository.adcontrol.di.clientRepositoryAdControlModule
+import com.oztechan.ccc.client.repository.appconfig.di.clientRepositoryAppConfigModule
+import com.oztechan.ccc.client.service.backend.di.clientServiceBackendModule
+import com.oztechan.ccc.client.storage.app.di.clientStorageAppModule
+import com.oztechan.ccc.client.storage.calculation.di.clientStorageCalculationModule
+import com.oztechan.ccc.client.viewmodel.calculator.di.clientViewModelCalculatorModule
+import com.oztechan.ccc.client.viewmodel.currencies.di.clientViewModelCurrenciesModule
+import com.oztechan.ccc.client.viewmodel.main.di.clientViewModelMainModule
+import com.oztechan.ccc.client.viewmodel.premium.di.clientViewModelPremiumModule
+import com.oztechan.ccc.client.viewmodel.selectcurrency.di.clientViewModelSelectCurrencyModule
+import com.oztechan.ccc.client.viewmodel.settings.di.clientViewModelSettingsModule
+import com.oztechan.ccc.client.viewmodel.watchers.di.clientViewModelWatchersModule
+import com.oztechan.ccc.common.core.database.di.commonCoreDatabaseModule
+import com.oztechan.ccc.common.core.infrastructure.di.commonCoreInfrastructureModule
+import com.oztechan.ccc.common.core.network.di.commonCoreNetworkModule
+import com.oztechan.ccc.common.datasource.conversion.di.commonDataSourceConversionModule
+import io.ktor.client.engine.HttpClientEngine
+import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.dsl.module
+import org.koin.test.verify.verify
+import kotlin.test.Test
+
+internal class AndroidKoinGraphTest {
+
+    @OptIn(KoinExperimentalAPI::class)
+    @Test
+    fun `android Koin graph has all dependencies declared`() {
+        module {
+            includes(
+                // Android modules
+                androidCoreAdModule,
+                androidCoreBillingModule,
+                androidViewModelWidgetModule,
+                // Client modules
+                clientCoreAnalyticsModule,
+                clientCorePersistenceModule,
+                clientStorageAppModule,
+                clientStorageCalculationModule,
+                clientServiceBackendModule,
+                clientConfigServiceAdModule,
+                clientConfigServiceUpdateModule,
+                clientConfigServiceReviewModel,
+                clientDataSourceCurrencyModule,
+                clientDataSourceWatcherModule,
+                clientRepositoryAdControlModule,
+                clientRepositoryAppConfigModule,
+                clientViewModelMainModule,
+                clientViewModelCalculatorModule,
+                clientViewModelCurrenciesModule,
+                clientViewModelSettingsModule,
+                clientViewModelSelectCurrencyModule,
+                clientViewModelWatchersModule,
+                clientViewModelPremiumModule,
+                // Common modules
+                commonCoreDatabaseModule,
+                commonCoreNetworkModule,
+                commonCoreInfrastructureModule,
+                commonDataSourceConversionModule
+            )
+        }.verify(
+            extraTypes = listOf(
+                // Provided by the private platform module / Ktor at runtime, not by the modules above.
+                Device::class,
+                Context::class,
+                HttpClientEngine::class
+            )
+        )
+    }
+}


### PR DESCRIPTION
Closes #4856. Follow-up to #4855 (backend graph) — same `verify()` approach for the Android app's assembled graph (client + common + android modules).

`verify()` is static (no instantiation), so it runs as a plain unit test. Platform-provided types (`Device` from the private platform module, `Context`) and Ktor's implicit `HttpClientEngine` are declared via `extraTypes`.

Because the Android graph includes every client + common module too, this verifies effectively the whole JVM-reachable DI graph. The iOS graph (`ios/provider`) assembles with iOS-only types (NSUserDefaults) on Kotlin/Native, where reflection-based `verify()` isn't available — out of scope for JVM unit tests.

**CI: green** (CodeAnalysis, Test, Coverage, GradleBuild, XCodeBuild).