### PR TITLE
[Oztechan/CCC#4877] Migrate SQLDelight 1.5.5 to app.cash.sqldelight 2.3.2

### DIFF
--- a/android/app/src/test/kotlin/com/oztechan/ccc/android/app/AndroidKoinGraphTest.kt
+++ b/android/app/src/test/kotlin/com/oztechan/ccc/android/app/AndroidKoinGraphTest.kt
@@ -1,6 +1,7 @@
 package com.oztechan.ccc.android.app
 
 import android.content.Context
+import app.cash.sqldelight.db.SqlDriver
 import com.oztechan.ccc.android.core.ad.di.androidCoreAdModule
 import com.oztechan.ccc.android.core.billing.di.androidCoreBillingModule
 import com.oztechan.ccc.android.viewmodel.widget.di.androidViewModelWidgetModule
@@ -76,7 +77,11 @@ internal class AndroidKoinGraphTest {
                 // Provided by the private platform module / Ktor at runtime, not by the modules above.
                 Device::class,
                 Context::class,
-                HttpClientEngine::class
+                HttpClientEngine::class,
+                // SQLDelight 2.x generates the *Queries types as final classes taking a SqlDriver.
+                // Koin never constructs them that way - they are read off the database instance -
+                // but verify() still inspects the constructor, so the driver has no binding.
+                SqlDriver::class
             )
         )
     }

--- a/backend/app/src/test/kotlin/com/oztechan/ccc/backend/app/KoinGraphTest.kt
+++ b/backend/app/src/test/kotlin/com/oztechan/ccc/backend/app/KoinGraphTest.kt
@@ -6,6 +6,7 @@ import com.oztechan.ccc.backend.service.premium.di.backendServicePremiumModule
 import com.oztechan.ccc.common.core.database.di.commonCoreDatabaseModule
 import com.oztechan.ccc.common.core.infrastructure.di.commonCoreInfrastructureModule
 import com.oztechan.ccc.common.core.network.di.commonCoreNetworkModule
+import app.cash.sqldelight.db.SqlDriver
 import com.oztechan.ccc.common.datasource.conversion.di.commonDataSourceConversionModule
 import io.ktor.client.engine.HttpClientEngine
 import org.koin.core.annotation.KoinExperimentalAPI
@@ -29,8 +30,14 @@ internal class KoinGraphTest {
                 commonDataSourceConversionModule
             )
         }.verify(
-            // Ktor picks the HttpClientEngine implicitly at runtime, so it has no Koin binding.
-            extraTypes = listOf(HttpClientEngine::class)
+            extraTypes = listOf(
+                // Ktor picks the HttpClientEngine implicitly at runtime, so it has no Koin binding.
+                HttpClientEngine::class,
+                // SQLDelight 2.x generates the *Queries types as final classes taking a SqlDriver.
+                // Koin never constructs them that way - they are read off the database instance -
+                // but verify() still inspects the constructor, so the driver has no binding.
+                SqlDriver::class
+            )
         )
     }
 }

--- a/backend/app/src/test/kotlin/com/oztechan/ccc/backend/app/KoinGraphTest.kt
+++ b/backend/app/src/test/kotlin/com/oztechan/ccc/backend/app/KoinGraphTest.kt
@@ -1,12 +1,12 @@
 package com.oztechan.ccc.backend.app
 
+import app.cash.sqldelight.db.SqlDriver
 import com.oztechan.ccc.backend.controller.api.di.backendControllerAPIModule
 import com.oztechan.ccc.backend.controller.sync.di.backendControllerSyncModule
 import com.oztechan.ccc.backend.service.premium.di.backendServicePremiumModule
 import com.oztechan.ccc.common.core.database.di.commonCoreDatabaseModule
 import com.oztechan.ccc.common.core.infrastructure.di.commonCoreInfrastructureModule
 import com.oztechan.ccc.common.core.network.di.commonCoreNetworkModule
-import app.cash.sqldelight.db.SqlDriver
 import com.oztechan.ccc.common.datasource.conversion.di.commonDataSourceConversionModule
 import io.ktor.client.engine.HttpClientEngine
 import org.koin.core.annotation.KoinExperimentalAPI

--- a/client/datasource/currency/client-datasource-currency.gradle.kts
+++ b/client/datasource/currency/client-datasource-currency.gradle.kts
@@ -18,6 +18,14 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
+    // The iOS test binaries pull in SQLDelight's native driver, which needs the system
+    // sqlite to be linked explicitly; sqldelight's own linkSqlite only covers :common:core:database.
+    targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>().configureEach {
+        binaries.withType<org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable>().configureEach {
+            linkerOpts("-lsqlite3")
+        }
+    }
+
     sourceSets {
         commonMain.dependencies {
             libs.common.apply {
@@ -36,6 +44,12 @@ kotlin {
                 implementation(test)
                 implementation(coroutinesTest)
             }
+        }
+        getByName("androidHostTest").dependencies {
+            implementation(libs.jvm.sqlliteDriver)
+        }
+        iosTest.dependencies {
+            implementation(libs.ios.sqlliteDriver)
         }
     }
 }

--- a/client/datasource/currency/src/androidHostTest/kotlin/com/oztechan/ccc/client/datasource/currency/TestSqlDriver.android.kt
+++ b/client/datasource/currency/src/androidHostTest/kotlin/com/oztechan/ccc/client/datasource/currency/TestSqlDriver.android.kt
@@ -1,0 +1,9 @@
+package com.oztechan.ccc.client.datasource.currency
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
+
+internal actual fun createTestSqlDriver(): SqlDriver =
+    JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        .also { CurrencyConverterCalculatorDatabase.Schema.create(it) }

--- a/client/datasource/currency/src/commonMain/kotlin/com/oztechan/ccc/client/datasource/currency/CurrencyDataSourceImpl.kt
+++ b/client/datasource/currency/src/commonMain/kotlin/com/oztechan/ccc/client/datasource/currency/CurrencyDataSourceImpl.kt
@@ -42,12 +42,12 @@ internal class CurrencyDataSourceImpl(
             .map { it.toCurrencyModel() }
     }
 
-    override suspend fun updateCurrencyStateByCode(code: String, isActive: Boolean) = dbQuery {
+    override suspend fun updateCurrencyStateByCode(code: String, isActive: Boolean): Unit = dbQuery {
         Logger.v { "CurrencyDataSourceImpl updateCurrencyStateByCode $code $isActive" }
         currencyQueries.updateCurrencyStateByCode(isActive.toLong(), code)
     }
 
-    override suspend fun updateCurrencyStates(value: Boolean) = dbQuery {
+    override suspend fun updateCurrencyStates(value: Boolean): Unit = dbQuery {
         Logger.v { "CurrencyDataSourceImpl updateCurrencyStates $value" }
         currencyQueries.updateCurrencyStates(value.toLong())
     }

--- a/client/datasource/currency/src/commonTest/kotlin/com/oztechan/ccc/client/datasource/currency/CurrencyDataSourceTest.kt
+++ b/client/datasource/currency/src/commonTest/kotlin/com/oztechan/ccc/client/datasource/currency/CurrencyDataSourceTest.kt
@@ -5,9 +5,9 @@ import co.touchlab.kermit.Logger
 import com.oztechan.ccc.common.core.database.mapper.toLong
 import com.oztechan.ccc.common.core.database.sql.Currency
 import com.oztechan.ccc.common.core.database.sql.CurrencyQueries
-import com.squareup.sqldelight.Query
-import com.squareup.sqldelight.db.SqlCursor
-import com.squareup.sqldelight.db.SqlDriver
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlDriver
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -31,7 +31,7 @@ internal class CurrencyDataSourceTest {
     private val sqlCursor = mock<SqlCursor>(MockMode.autoUnit)
 
     private val currency = Currency("EUR", "", "", 0.0, 0L)
-    private val query = Query(-1, mutableListOf(), sqlDriver, query = "") {
+    private val query = Query(-1, emptyArray(), sqlDriver, query = "") {
         currency
     }
 

--- a/client/datasource/currency/src/commonTest/kotlin/com/oztechan/ccc/client/datasource/currency/CurrencyDataSourceTest.kt
+++ b/client/datasource/currency/src/commonTest/kotlin/com/oztechan/ccc/client/datasource/currency/CurrencyDataSourceTest.kt
@@ -1,13 +1,13 @@
 package com.oztechan.ccc.client.datasource.currency
 
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlDriver
 import co.touchlab.kermit.CommonWriter
 import co.touchlab.kermit.Logger
 import com.oztechan.ccc.common.core.database.mapper.toLong
 import com.oztechan.ccc.common.core.database.sql.Currency
 import com.oztechan.ccc.common.core.database.sql.CurrencyQueries
-import app.cash.sqldelight.Query
-import app.cash.sqldelight.db.SqlCursor
-import app.cash.sqldelight.db.SqlDriver
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every

--- a/client/datasource/currency/src/commonTest/kotlin/com/oztechan/ccc/client/datasource/currency/CurrencyDataSourceTest.kt
+++ b/client/datasource/currency/src/commonTest/kotlin/com/oztechan/ccc/client/datasource/currency/CurrencyDataSourceTest.kt
@@ -1,119 +1,110 @@
 package com.oztechan.ccc.client.datasource.currency
 
-import app.cash.sqldelight.Query
-import app.cash.sqldelight.db.SqlCursor
-import app.cash.sqldelight.db.SqlDriver
 import co.touchlab.kermit.CommonWriter
 import co.touchlab.kermit.Logger
-import com.oztechan.ccc.common.core.database.mapper.toLong
-import com.oztechan.ccc.common.core.database.sql.Currency
-import com.oztechan.ccc.common.core.database.sql.CurrencyQueries
-import dev.mokkery.MockMode
-import dev.mokkery.answering.returns
-import dev.mokkery.every
-import dev.mokkery.mock
-import dev.mokkery.verify
+import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import kotlin.random.Random
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 internal class CurrencyDataSourceTest {
 
+    private val driver = createTestSqlDriver()
+
     private val subject: CurrencyDataSource by lazy {
         @Suppress("OPT_IN_USAGE")
-        CurrencyDataSourceImpl(currencyQueries, UnconfinedTestDispatcher())
-    }
-
-    private val currencyQueries = mock<CurrencyQueries>(MockMode.autoUnit)
-    private val sqlDriver = mock<SqlDriver>()
-    private val sqlCursor = mock<SqlCursor>(MockMode.autoUnit)
-
-    private val currency = Currency("EUR", "", "", 0.0, 0L)
-    private val query = Query(-1, emptyArray(), sqlDriver, query = "") {
-        currency
+        CurrencyDataSourceImpl(
+            CurrencyConverterCalculatorDatabase(driver).currencyQueries,
+            UnconfinedTestDispatcher()
+        )
     }
 
     @BeforeTest
     fun setup() {
         Logger.setLogWriters(CommonWriter())
+    }
 
-        every { sqlDriver.executeQuery(-1, "", 0, null) }
-            .returns(sqlCursor)
-
-        every { sqlCursor.next() }
-            .returns(false)
+    @AfterTest
+    fun tearDown() {
+        driver.close()
     }
 
     @Test
-    fun getCurrenciesFlow() {
-        every { currencyQueries.getCurrencies() }
-            .returns(query)
+    fun getCurrenciesFlow() = runTest {
+        val currencies = subject.getCurrenciesFlow().first()
 
-        runTest {
-            subject.getCurrenciesFlow()
-        }
-
-        verify { currencyQueries.getCurrencies() }
+        assertTrue { currencies.isNotEmpty() }
+        assertEquals(currencies.sortedBy { it.code }, currencies)
     }
 
     @Test
-    fun getActiveCurrenciesFlow() {
-        every { currencyQueries.getActiveCurrencies() }
-            .returns(query)
+    fun getActiveCurrenciesFlow() = runTest {
+        assertTrue { subject.getActiveCurrenciesFlow().first().isEmpty() }
 
-        runTest {
-            subject.getActiveCurrenciesFlow()
-        }
+        subject.updateCurrencyStateByCode(EUR, true)
 
-        verify { currencyQueries.getActiveCurrencies() }
+        assertEquals(
+            listOf(EUR),
+            subject.getActiveCurrenciesFlow().first().map { it.code }
+        )
     }
 
     @Test
-    fun getActiveCurrencies() {
-        every { currencyQueries.getActiveCurrencies() }
-            .returns(query)
+    fun getActiveCurrencies() = runTest {
+        assertTrue { subject.getActiveCurrencies().isEmpty() }
 
-        runTest {
-            subject.getActiveCurrencies()
-        }
+        subject.updateCurrencyStateByCode(EUR, true)
 
-        verify { currencyQueries.getActiveCurrencies() }
+        assertEquals(listOf(EUR), subject.getActiveCurrencies().map { it.code })
     }
 
     @Test
-    fun updateCurrencyStateByCode() {
-        val mockCode = "mock"
-        val mockState = Random.nextBoolean()
+    fun updateCurrencyStateByCode() = runTest {
+        subject.updateCurrencyStateByCode(EUR, true)
 
-        runTest {
-            subject.updateCurrencyStateByCode(mockCode, mockState)
-        }
+        assertTrue { subject.getCurrencyByCode(EUR)?.isActive == true }
 
-        verify { currencyQueries.updateCurrencyStateByCode(mockState.toLong(), mockCode) }
+        subject.updateCurrencyStateByCode(EUR, false)
+
+        assertFalse { subject.getCurrencyByCode(EUR)?.isActive == true }
     }
 
     @Test
-    fun updateCurrencyStates() {
-        val mockState = Random.nextBoolean()
+    fun updateCurrencyStates() = runTest {
+        subject.updateCurrencyStates(true)
 
-        runTest {
-            subject.updateCurrencyStates(mockState)
-        }
+        assertEquals(
+            subject.getCurrenciesFlow().first().size,
+            subject.getActiveCurrencies().size
+        )
 
-        verify { currencyQueries.updateCurrencyStates(mockState.toLong()) }
+        subject.updateCurrencyStates(false)
+
+        assertTrue { subject.getActiveCurrencies().isEmpty() }
     }
 
     @Test
-    fun getCurrencyByCode() {
-        every { currencyQueries.getCurrencyByCode(currency.code) }
-            .returns(query)
+    fun getCurrencyByCode() = runTest {
+        val currency = subject.getCurrencyByCode(EUR)
 
-        runTest {
-            subject.getCurrencyByCode(currency.code)
-        }
+        assertEquals(EUR, currency?.code)
+        assertEquals("Euro", currency?.name)
+        assertFalse { currency?.isActive == true }
+    }
 
-        verify { currencyQueries.getCurrencyByCode(currency.code) }
+    @Test
+    fun getCurrencyByCodeReturnsNullForUnknownCode() = runTest {
+        assertNull(subject.getCurrencyByCode("UNKNOWN"))
+    }
+
+    companion object {
+        private const val EUR = "EUR"
     }
 }

--- a/client/datasource/currency/src/commonTest/kotlin/com/oztechan/ccc/client/datasource/currency/TestSqlDriver.kt
+++ b/client/datasource/currency/src/commonTest/kotlin/com/oztechan/ccc/client/datasource/currency/TestSqlDriver.kt
@@ -1,0 +1,9 @@
+package com.oztechan.ccc.client.datasource.currency
+
+import app.cash.sqldelight.db.SqlDriver
+
+/**
+ * An in-memory driver with the schema applied, so tests exercise real SQL instead of mocks.
+ * SQLDelight 2.x generates final query classes, which cannot be mocked on Kotlin/Native.
+ */
+internal expect fun createTestSqlDriver(): SqlDriver

--- a/client/datasource/currency/src/iosTest/kotlin/com/oztechan/ccc/client/datasource/currency/TestSqlDriver.ios.kt
+++ b/client/datasource/currency/src/iosTest/kotlin/com/oztechan/ccc/client/datasource/currency/TestSqlDriver.ios.kt
@@ -1,0 +1,8 @@
+package com.oztechan.ccc.client.datasource.currency
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.native.inMemoryDriver
+import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
+
+internal actual fun createTestSqlDriver(): SqlDriver =
+    inMemoryDriver(CurrencyConverterCalculatorDatabase.Schema)

--- a/client/datasource/watcher/client-datasource-watcher.gradle.kts
+++ b/client/datasource/watcher/client-datasource-watcher.gradle.kts
@@ -18,6 +18,14 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
+    // The iOS test binaries pull in SQLDelight's native driver, which needs the system
+    // sqlite to be linked explicitly; sqldelight's own linkSqlite only covers :common:core:database.
+    targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>().configureEach {
+        binaries.withType<org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable>().configureEach {
+            linkerOpts("-lsqlite3")
+        }
+    }
+
     sourceSets {
         commonMain.dependencies {
             libs.common.apply {
@@ -36,6 +44,12 @@ kotlin {
                 implementation(test)
                 implementation(coroutinesTest)
             }
+        }
+        getByName("androidHostTest").dependencies {
+            implementation(libs.jvm.sqlliteDriver)
+        }
+        iosTest.dependencies {
+            implementation(libs.ios.sqlliteDriver)
         }
     }
 }

--- a/client/datasource/watcher/src/androidHostTest/kotlin/com/oztechan/ccc/client/datasource/watcher/TestSqlDriver.android.kt
+++ b/client/datasource/watcher/src/androidHostTest/kotlin/com/oztechan/ccc/client/datasource/watcher/TestSqlDriver.android.kt
@@ -1,0 +1,9 @@
+package com.oztechan.ccc.client.datasource.watcher
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
+
+internal actual fun createTestSqlDriver(): SqlDriver =
+    JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        .also { CurrencyConverterCalculatorDatabase.Schema.create(it) }

--- a/client/datasource/watcher/src/commonMain/kotlin/com/oztechan/ccc/client/datasource/watcher/WatcherDataSourceImpl.kt
+++ b/client/datasource/watcher/src/commonMain/kotlin/com/oztechan/ccc/client/datasource/watcher/WatcherDataSourceImpl.kt
@@ -24,7 +24,7 @@ internal class WatcherDataSourceImpl(
             }
     }
 
-    override suspend fun addWatcher(base: String, target: String) = dbQuery {
+    override suspend fun addWatcher(base: String, target: String): Unit = dbQuery {
         Logger.v { "WatcherDataSourceImpl addWatcher $base $target" }
         watcherQueries.addWatcher(base, target)
     }
@@ -36,27 +36,27 @@ internal class WatcherDataSourceImpl(
             .map { it.toWatcherModel() }
     }
 
-    override suspend fun deleteWatcher(id: Long) = dbQuery {
+    override suspend fun deleteWatcher(id: Long): Unit = dbQuery {
         Logger.v { "WatcherDataSourceImpl deleteWatcher $id" }
         watcherQueries.deleteWatcher(id)
     }
 
-    override suspend fun updateWatcherBaseById(base: String, id: Long) = dbQuery {
+    override suspend fun updateWatcherBaseById(base: String, id: Long): Unit = dbQuery {
         Logger.v { "WatcherDataSourceImpl updateWatcherBaseById $base $id" }
         watcherQueries.updateWatcherBaseById(base, id)
     }
 
-    override suspend fun updateWatcherTargetById(target: String, id: Long) = dbQuery {
+    override suspend fun updateWatcherTargetById(target: String, id: Long): Unit = dbQuery {
         Logger.v { "WatcherDataSourceImpl updateWatcherTargetById $target $id" }
         watcherQueries.updateWatcherTargetById(target, id)
     }
 
-    override suspend fun updateWatcherRelationById(isGreater: Boolean, id: Long) = dbQuery {
+    override suspend fun updateWatcherRelationById(isGreater: Boolean, id: Long): Unit = dbQuery {
         Logger.v { "WatcherDataSourceImpl updateWatcherRelationById $isGreater $id" }
         watcherQueries.updateWatcherRelationById(isGreater.toLong(), id)
     }
 
-    override suspend fun updateWatcherRateById(rate: Double, id: Long) = dbQuery {
+    override suspend fun updateWatcherRateById(rate: Double, id: Long): Unit = dbQuery {
         Logger.v { "WatcherDataSourceImpl updateWatcherRateById $rate $id" }
         watcherQueries.updateWatcherRateById(rate, id)
     }

--- a/client/datasource/watcher/src/commonTest/kotlin/com/oztechan/ccc/client/datasource/watcher/TestSqlDriver.kt
+++ b/client/datasource/watcher/src/commonTest/kotlin/com/oztechan/ccc/client/datasource/watcher/TestSqlDriver.kt
@@ -1,0 +1,9 @@
+package com.oztechan.ccc.client.datasource.watcher
+
+import app.cash.sqldelight.db.SqlDriver
+
+/**
+ * An in-memory driver with the schema applied, so tests exercise real SQL instead of mocks.
+ * SQLDelight 2.x generates final query classes, which cannot be mocked on Kotlin/Native.
+ */
+internal expect fun createTestSqlDriver(): SqlDriver

--- a/client/datasource/watcher/src/commonTest/kotlin/com/oztechan/ccc/client/datasource/watcher/WatcherDataSourceTest.kt
+++ b/client/datasource/watcher/src/commonTest/kotlin/com/oztechan/ccc/client/datasource/watcher/WatcherDataSourceTest.kt
@@ -1,13 +1,13 @@
 package com.oztechan.ccc.client.datasource.watcher
 
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlDriver
 import co.touchlab.kermit.CommonWriter
 import co.touchlab.kermit.Logger
 import com.oztechan.ccc.common.core.database.mapper.toLong
 import com.oztechan.ccc.common.core.database.sql.Watcher
 import com.oztechan.ccc.common.core.database.sql.WatcherQueries
-import app.cash.sqldelight.Query
-import app.cash.sqldelight.db.SqlCursor
-import app.cash.sqldelight.db.SqlDriver
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every

--- a/client/datasource/watcher/src/commonTest/kotlin/com/oztechan/ccc/client/datasource/watcher/WatcherDataSourceTest.kt
+++ b/client/datasource/watcher/src/commonTest/kotlin/com/oztechan/ccc/client/datasource/watcher/WatcherDataSourceTest.kt
@@ -1,116 +1,121 @@
 package com.oztechan.ccc.client.datasource.watcher
 
-import app.cash.sqldelight.Query
-import app.cash.sqldelight.db.SqlCursor
-import app.cash.sqldelight.db.SqlDriver
 import co.touchlab.kermit.CommonWriter
 import co.touchlab.kermit.Logger
-import com.oztechan.ccc.common.core.database.mapper.toLong
-import com.oztechan.ccc.common.core.database.sql.Watcher
-import com.oztechan.ccc.common.core.database.sql.WatcherQueries
-import dev.mokkery.MockMode
-import dev.mokkery.answering.returns
-import dev.mokkery.every
-import dev.mokkery.mock
-import dev.mokkery.verify
+import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import kotlin.random.Random
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 internal class WatcherDataSourceTest {
 
+    private val driver = createTestSqlDriver()
+
     private val subject: WatcherDataSource by lazy {
         @Suppress("OPT_IN_USAGE")
-        WatcherDataSourceImpl(watcherQueries, UnconfinedTestDispatcher())
-    }
-
-    private val watcherQueries = mock<WatcherQueries>(MockMode.autoUnit)
-    private val sqlDriver = mock<SqlDriver>()
-    private val sqlCursor = mock<SqlCursor>(MockMode.autoUnit)
-
-    private val base = "EUR"
-    private val target = "USD"
-    private val id = 12L
-
-    private val query = Query(-1, emptyArray(), sqlDriver, query = "") {
-        Watcher(id, base, target, 1L, 0.0)
+        WatcherDataSourceImpl(
+            CurrencyConverterCalculatorDatabase(driver).watcherQueries,
+            UnconfinedTestDispatcher()
+        )
     }
 
     @BeforeTest
     fun setup() {
         Logger.setLogWriters(CommonWriter())
+    }
 
-        every { sqlDriver.executeQuery(-1, "", 0, null) }
-            .returns(sqlCursor)
-
-        every { sqlCursor.next() }
-            .returns(false)
+    @AfterTest
+    fun tearDown() {
+        driver.close()
     }
 
     @Test
     fun getWatchersFlow() = runTest {
-        every { watcherQueries.getWatchers() }
-            .returns(query)
+        assertTrue { subject.getWatchersFlow().first().isEmpty() }
 
-        subject.getWatchersFlow()
+        subject.addWatcher(BASE, TARGET)
 
-        verify { watcherQueries.getWatchers() }
+        assertEquals(1, subject.getWatchersFlow().first().size)
     }
 
     @Test
     fun addWatcher() = runTest {
-        subject.addWatcher(base, target)
+        subject.addWatcher(BASE, TARGET)
 
-        verify { watcherQueries.addWatcher(base, target) }
+        val watcher = subject.getWatchers().single()
+
+        assertEquals(BASE, watcher.source)
+        assertEquals(TARGET, watcher.target)
+        assertTrue { watcher.isGreater }
+        assertEquals(0.0, watcher.rate)
     }
 
     @Test
     fun getWatchers() = runTest {
-        every { watcherQueries.getWatchers() }
-            .returns(query)
+        assertTrue { subject.getWatchers().isEmpty() }
 
-        subject.getWatchers()
+        subject.addWatcher(BASE, TARGET)
+        subject.addWatcher(TARGET, BASE)
 
-        verify { watcherQueries.getWatchers() }
+        assertEquals(2, subject.getWatchers().size)
     }
 
     @Test
     fun deleteWatcher() = runTest {
-        subject.deleteWatcher(id)
+        subject.addWatcher(BASE, TARGET)
 
-        verify { watcherQueries.deleteWatcher(id) }
+        subject.deleteWatcher(subject.getWatchers().single().id)
+
+        assertTrue { subject.getWatchers().isEmpty() }
     }
 
     @Test
     fun updateWatcherBaseById() = runTest {
-        subject.updateWatcherBaseById(base, id)
+        subject.addWatcher(BASE, TARGET)
+        val id = subject.getWatchers().single().id
 
-        verify { watcherQueries.updateWatcherBaseById(base, id) }
+        subject.updateWatcherBaseById(TARGET, id)
+
+        assertEquals(TARGET, subject.getWatchers().single().source)
     }
 
     @Test
     fun updateWatcherTargetById() = runTest {
-        subject.updateWatcherTargetById(target, id)
+        subject.addWatcher(BASE, TARGET)
+        val id = subject.getWatchers().single().id
 
-        verify { watcherQueries.updateWatcherTargetById(target, id) }
+        subject.updateWatcherTargetById(BASE, id)
+
+        assertEquals(BASE, subject.getWatchers().single().target)
     }
 
     @Test
     fun updateWatcherRelationById() = runTest {
-        val relation = Random.nextBoolean()
-        subject.updateWatcherRelationById(relation, id)
+        subject.addWatcher(BASE, TARGET)
+        val id = subject.getWatchers().single().id
 
-        verify { watcherQueries.updateWatcherRelationById(relation.toLong(), id) }
+        subject.updateWatcherRelationById(false, id)
+
+        assertEquals(false, subject.getWatchers().single().isGreater)
     }
 
     @Test
     fun updateWatcherRateById() = runTest {
-        val rate = 1.2
+        subject.addWatcher(BASE, TARGET)
+        val id = subject.getWatchers().single().id
 
-        subject.updateWatcherRateById(rate, id)
+        subject.updateWatcherRateById(1.2, id)
 
-        verify { watcherQueries.updateWatcherRateById(rate, id) }
+        assertEquals(1.2, subject.getWatchers().single().rate)
+    }
+
+    companion object {
+        private const val BASE = "EUR"
+        private const val TARGET = "USD"
     }
 }

--- a/client/datasource/watcher/src/commonTest/kotlin/com/oztechan/ccc/client/datasource/watcher/WatcherDataSourceTest.kt
+++ b/client/datasource/watcher/src/commonTest/kotlin/com/oztechan/ccc/client/datasource/watcher/WatcherDataSourceTest.kt
@@ -5,9 +5,9 @@ import co.touchlab.kermit.Logger
 import com.oztechan.ccc.common.core.database.mapper.toLong
 import com.oztechan.ccc.common.core.database.sql.Watcher
 import com.oztechan.ccc.common.core.database.sql.WatcherQueries
-import com.squareup.sqldelight.Query
-import com.squareup.sqldelight.db.SqlCursor
-import com.squareup.sqldelight.db.SqlDriver
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlDriver
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -34,7 +34,7 @@ internal class WatcherDataSourceTest {
     private val target = "USD"
     private val id = 12L
 
-    private val query = Query(-1, mutableListOf(), sqlDriver, query = "") {
+    private val query = Query(-1, emptyArray(), sqlDriver, query = "") {
         Watcher(id, base, target, 1L, 0.0)
     }
 

--- a/client/datasource/watcher/src/iosTest/kotlin/com/oztechan/ccc/client/datasource/watcher/TestSqlDriver.ios.kt
+++ b/client/datasource/watcher/src/iosTest/kotlin/com/oztechan/ccc/client/datasource/watcher/TestSqlDriver.ios.kt
@@ -1,0 +1,8 @@
+package com.oztechan.ccc.client.datasource.watcher
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.native.inMemoryDriver
+import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
+
+internal actual fun createTestSqlDriver(): SqlDriver =
+    inMemoryDriver(CurrencyConverterCalculatorDatabase.Schema)

--- a/common/core/database/common-core-database.gradle.kts
+++ b/common/core/database/common-core-database.gradle.kts
@@ -49,9 +49,11 @@ kotlin {
 }
 
 sqldelight {
-    database("CurrencyConverterCalculatorDatabase") {
-        packageName = "${Modules.Common.Core.database.packageName}.sql"
-        sourceFolders = listOf("sql")
-        linkSqlite = true
+    linkSqlite.set(true)
+    databases {
+        create("CurrencyConverterCalculatorDatabase") {
+            packageName.set("${Modules.Common.Core.database.packageName}.sql")
+            srcDirs.setFrom("src/commonMain/sql")
+        }
     }
 }

--- a/common/core/database/src/androidMain/kotlin/com/oztechan/ccc/common/core/database/di/CommonCoreDatabaseModule.android.kt
+++ b/common/core/database/src/androidMain/kotlin/com/oztechan/ccc/common/core/database/di/CommonCoreDatabaseModule.android.kt
@@ -1,7 +1,7 @@
 package com.oztechan.ccc.common.core.database.di
 
-import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
+import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
 import org.koin.core.scope.Scope
 
 actual fun Scope.provideDatabase(databaseName: String) = CurrencyConverterCalculatorDatabase(

--- a/common/core/database/src/androidMain/kotlin/com/oztechan/ccc/common/core/database/di/CommonCoreDatabaseModule.android.kt
+++ b/common/core/database/src/androidMain/kotlin/com/oztechan/ccc/common/core/database/di/CommonCoreDatabaseModule.android.kt
@@ -1,7 +1,7 @@
 package com.oztechan.ccc.common.core.database.di
 
 import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
-import com.squareup.sqldelight.android.AndroidSqliteDriver
+import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import org.koin.core.scope.Scope
 
 actual fun Scope.provideDatabase(databaseName: String) = CurrencyConverterCalculatorDatabase(

--- a/common/core/database/src/commonMain/kotlin/com/oztechan/ccc/common/core/database/base/BaseDBDataSource.kt
+++ b/common/core/database/src/commonMain/kotlin/com/oztechan/ccc/common/core/database/base/BaseDBDataSource.kt
@@ -2,9 +2,9 @@ package com.oztechan.ccc.common.core.database.base
 
 import co.touchlab.kermit.Logger
 import com.oztechan.ccc.common.core.database.error.DatabaseException
-import com.squareup.sqldelight.Query
-import com.squareup.sqldelight.runtime.coroutines.asFlow
-import com.squareup.sqldelight.runtime.coroutines.mapToList
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch

--- a/common/core/database/src/commonMain/kotlin/com/oztechan/ccc/common/core/database/base/BaseDBDataSource.kt
+++ b/common/core/database/src/commonMain/kotlin/com/oztechan/ccc/common/core/database/base/BaseDBDataSource.kt
@@ -1,10 +1,10 @@
 package com.oztechan.ccc.common.core.database.base
 
-import co.touchlab.kermit.Logger
-import com.oztechan.ccc.common.core.database.error.DatabaseException
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
+import co.touchlab.kermit.Logger
+import com.oztechan.ccc.common.core.database.error.DatabaseException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch

--- a/common/core/database/src/iosMain/kotlin/com/oztechan/ccc/common/core/database/di/CommonCoreDatabaseModule.ios.kt
+++ b/common/core/database/src/iosMain/kotlin/com/oztechan/ccc/common/core/database/di/CommonCoreDatabaseModule.ios.kt
@@ -1,7 +1,7 @@
 package com.oztechan.ccc.common.core.database.di
 
 import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
-import com.squareup.sqldelight.drivers.native.NativeSqliteDriver
+import app.cash.sqldelight.driver.native.NativeSqliteDriver
 import org.koin.core.scope.Scope
 
 actual fun Scope.provideDatabase(databaseName: String) = CurrencyConverterCalculatorDatabase(

--- a/common/core/database/src/iosMain/kotlin/com/oztechan/ccc/common/core/database/di/CommonCoreDatabaseModule.ios.kt
+++ b/common/core/database/src/iosMain/kotlin/com/oztechan/ccc/common/core/database/di/CommonCoreDatabaseModule.ios.kt
@@ -1,7 +1,7 @@
 package com.oztechan.ccc.common.core.database.di
 
-import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
+import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
 import org.koin.core.scope.Scope
 
 actual fun Scope.provideDatabase(databaseName: String) = CurrencyConverterCalculatorDatabase(

--- a/common/core/database/src/jvmMain/kotlin/com/oztechan/ccc/common/core/database/di/CommonCoreDatabaseModule.jvm.kt
+++ b/common/core/database/src/jvmMain/kotlin/com/oztechan/ccc/common/core/database/di/CommonCoreDatabaseModule.jvm.kt
@@ -1,7 +1,7 @@
 package com.oztechan.ccc.common.core.database.di
 
 import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
-import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import org.koin.core.scope.Scope
 
 actual fun Scope.provideDatabase(databaseName: String) = CurrencyConverterCalculatorDatabase(

--- a/common/core/database/src/jvmMain/kotlin/com/oztechan/ccc/common/core/database/di/CommonCoreDatabaseModule.jvm.kt
+++ b/common/core/database/src/jvmMain/kotlin/com/oztechan/ccc/common/core/database/di/CommonCoreDatabaseModule.jvm.kt
@@ -1,7 +1,7 @@
 package com.oztechan.ccc.common.core.database.di
 
-import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
 import org.koin.core.scope.Scope
 
 actual fun Scope.provideDatabase(databaseName: String) = CurrencyConverterCalculatorDatabase(

--- a/common/datasource/conversion/common-datasource-conversion.gradle.kts
+++ b/common/datasource/conversion/common-datasource-conversion.gradle.kts
@@ -20,6 +20,14 @@ kotlin {
 
     jvm()
 
+    // The iOS test binaries pull in SQLDelight's native driver, which needs the system
+    // sqlite to be linked explicitly; sqldelight's own linkSqlite only covers :common:core:database.
+    targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>().configureEach {
+        binaries.withType<org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable>().configureEach {
+            linkerOpts("-lsqlite3")
+        }
+    }
+
     sourceSets {
         commonMain.dependencies {
             libs.common.apply {
@@ -38,6 +46,15 @@ kotlin {
                 implementation(test)
                 implementation(coroutinesTest)
             }
+        }
+        getByName("androidHostTest").dependencies {
+            implementation(libs.jvm.sqlliteDriver)
+        }
+        iosTest.dependencies {
+            implementation(libs.ios.sqlliteDriver)
+        }
+        jvmTest.dependencies {
+            implementation(libs.jvm.sqlliteDriver)
         }
     }
 }

--- a/common/datasource/conversion/src/androidHostTest/kotlin/com/oztechan/ccc/common/datasource/conversion/TestSqlDriver.android.kt
+++ b/common/datasource/conversion/src/androidHostTest/kotlin/com/oztechan/ccc/common/datasource/conversion/TestSqlDriver.android.kt
@@ -1,0 +1,9 @@
+package com.oztechan.ccc.common.datasource.conversion
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
+
+internal actual fun createTestSqlDriver(): SqlDriver =
+    JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        .also { CurrencyConverterCalculatorDatabase.Schema.create(it) }

--- a/common/datasource/conversion/src/commonMain/kotlin/com/oztechan/ccc/common/datasource/conversion/ConversionDataSourceImpl.kt
+++ b/common/datasource/conversion/src/commonMain/kotlin/com/oztechan/ccc/common/datasource/conversion/ConversionDataSourceImpl.kt
@@ -13,7 +13,7 @@ internal class ConversionDataSourceImpl(
     ioDispatcher: CoroutineDispatcher
 ) : ConversionDataSource, BaseDBDataSource(ioDispatcher) {
 
-    override suspend fun insertConversion(conversion: Conversion) = dbQuery {
+    override suspend fun insertConversion(conversion: Conversion): Unit = dbQuery {
         Logger.v { "ConversionDataSourceImpl insertConversion ${conversion.base}" }
         conversionQueries.insertConversion(conversion.toConversionDBModel())
     }

--- a/common/datasource/conversion/src/commonTest/kotlin/com/oztechan/ccc/common/datasource/conversion/ConversionDataSourceTest.kt
+++ b/common/datasource/conversion/src/commonTest/kotlin/com/oztechan/ccc/common/datasource/conversion/ConversionDataSourceTest.kt
@@ -1,67 +1,76 @@
 package com.oztechan.ccc.common.datasource.conversion
 
-import app.cash.sqldelight.Query
-import app.cash.sqldelight.db.SqlCursor
-import app.cash.sqldelight.db.SqlDriver
 import co.touchlab.kermit.CommonWriter
 import co.touchlab.kermit.Logger
-import com.oztechan.ccc.common.core.database.sql.ConversionQueries
+import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
 import com.oztechan.ccc.common.datasource.conversion.fakes.Fakes
-import com.oztechan.ccc.common.datasource.conversion.mapper.toConversionDBModel
-import dev.mokkery.MockMode
-import dev.mokkery.answering.returns
-import dev.mokkery.every
-import dev.mokkery.mock
-import dev.mokkery.verify
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 internal class ConversionDataSourceTest {
 
+    private val driver = createTestSqlDriver()
+
     private val subject: ConversionDataSource by lazy {
         @Suppress("OPT_IN_USAGE")
-        ConversionDataSourceImpl(conversionQueries, UnconfinedTestDispatcher())
-    }
-
-    private val conversionQueries = mock<ConversionQueries>(MockMode.autoUnit)
-    private val sqlDriver = mock<SqlDriver>()
-    private val sqlCursor = mock<SqlCursor>(MockMode.autoUnit)
-
-    private val query = Query(-1, emptyArray(), sqlDriver, query = "") {
-        Fakes.conversionModel.toConversionDBModel()
+        ConversionDataSourceImpl(
+            CurrencyConverterCalculatorDatabase(driver).conversionQueries,
+            UnconfinedTestDispatcher()
+        )
     }
 
     @BeforeTest
     fun setup() {
         Logger.setLogWriters(CommonWriter())
+    }
 
-        every { sqlDriver.executeQuery(-1, "", 0, null) }
-            .returns(sqlCursor)
-
-        every { sqlCursor.next() }
-            .returns(false)
+    @AfterTest
+    fun tearDown() {
+        driver.close()
     }
 
     @Test
-    fun insertConversion() {
-        runTest {
-            subject.insertConversion(Fakes.conversionModel)
-        }
+    fun insertConversion() = runTest {
+        subject.insertConversion(Fakes.conversionModel)
 
-        verify { conversionQueries.insertConversion(Fakes.conversionModel.toConversionDBModel()) }
-    }
-
-    @Test
-    fun getConversionByBase() {
-        every { conversionQueries.getConversionByBase(Fakes.conversionModel.base) }
-            .returns(query)
-
-        runTest {
+        assertEquals(
+            Fakes.conversionModel,
             subject.getConversionByBase(Fakes.conversionModel.base)
-        }
+        )
+    }
 
-        verify { conversionQueries.getConversionByBase(Fakes.conversionModel.base) }
+    @Test
+    fun insertConversionReplacesExistingBase() = runTest {
+        subject.insertConversion(Fakes.conversionModel)
+        subject.insertConversion(Fakes.conversionModel.copy(date = "01.01.2023"))
+
+        assertEquals(
+            "01.01.2023",
+            subject.getConversionByBase(Fakes.conversionModel.base)?.date
+        )
+    }
+
+    @Test
+    fun getConversionByBase() = runTest {
+        assertNull(subject.getConversionByBase(Fakes.conversionModel.base))
+
+        subject.insertConversion(Fakes.conversionModel)
+
+        assertEquals(
+            Fakes.conversionModel,
+            subject.getConversionByBase(Fakes.conversionModel.base)
+        )
+    }
+
+    @Test
+    fun getConversionByBaseReturnsNullForUnknownBase() = runTest {
+        subject.insertConversion(Fakes.conversionModel)
+
+        assertNull(subject.getConversionByBase("UNKNOWN"))
     }
 }

--- a/common/datasource/conversion/src/commonTest/kotlin/com/oztechan/ccc/common/datasource/conversion/ConversionDataSourceTest.kt
+++ b/common/datasource/conversion/src/commonTest/kotlin/com/oztechan/ccc/common/datasource/conversion/ConversionDataSourceTest.kt
@@ -5,9 +5,9 @@ import co.touchlab.kermit.Logger
 import com.oztechan.ccc.common.core.database.sql.ConversionQueries
 import com.oztechan.ccc.common.datasource.conversion.fakes.Fakes
 import com.oztechan.ccc.common.datasource.conversion.mapper.toConversionDBModel
-import com.squareup.sqldelight.Query
-import com.squareup.sqldelight.db.SqlCursor
-import com.squareup.sqldelight.db.SqlDriver
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlDriver
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -29,7 +29,7 @@ internal class ConversionDataSourceTest {
     private val sqlDriver = mock<SqlDriver>()
     private val sqlCursor = mock<SqlCursor>(MockMode.autoUnit)
 
-    private val query = Query(-1, mutableListOf(), sqlDriver, query = "") {
+    private val query = Query(-1, emptyArray(), sqlDriver, query = "") {
         Fakes.conversionModel.toConversionDBModel()
     }
 

--- a/common/datasource/conversion/src/commonTest/kotlin/com/oztechan/ccc/common/datasource/conversion/ConversionDataSourceTest.kt
+++ b/common/datasource/conversion/src/commonTest/kotlin/com/oztechan/ccc/common/datasource/conversion/ConversionDataSourceTest.kt
@@ -1,13 +1,13 @@
 package com.oztechan.ccc.common.datasource.conversion
 
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlDriver
 import co.touchlab.kermit.CommonWriter
 import co.touchlab.kermit.Logger
 import com.oztechan.ccc.common.core.database.sql.ConversionQueries
 import com.oztechan.ccc.common.datasource.conversion.fakes.Fakes
 import com.oztechan.ccc.common.datasource.conversion.mapper.toConversionDBModel
-import app.cash.sqldelight.Query
-import app.cash.sqldelight.db.SqlCursor
-import app.cash.sqldelight.db.SqlDriver
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every

--- a/common/datasource/conversion/src/commonTest/kotlin/com/oztechan/ccc/common/datasource/conversion/TestSqlDriver.kt
+++ b/common/datasource/conversion/src/commonTest/kotlin/com/oztechan/ccc/common/datasource/conversion/TestSqlDriver.kt
@@ -1,0 +1,9 @@
+package com.oztechan.ccc.common.datasource.conversion
+
+import app.cash.sqldelight.db.SqlDriver
+
+/**
+ * An in-memory driver with the schema applied, so tests exercise real SQL instead of mocks.
+ * SQLDelight 2.x generates final query classes, which cannot be mocked on Kotlin/Native.
+ */
+internal expect fun createTestSqlDriver(): SqlDriver

--- a/common/datasource/conversion/src/iosTest/kotlin/com/oztechan/ccc/common/datasource/conversion/TestSqlDriver.ios.kt
+++ b/common/datasource/conversion/src/iosTest/kotlin/com/oztechan/ccc/common/datasource/conversion/TestSqlDriver.ios.kt
@@ -1,0 +1,8 @@
+package com.oztechan.ccc.common.datasource.conversion
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.native.inMemoryDriver
+import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
+
+internal actual fun createTestSqlDriver(): SqlDriver =
+    inMemoryDriver(CurrencyConverterCalculatorDatabase.Schema)

--- a/common/datasource/conversion/src/jvmTest/kotlin/com/oztechan/ccc/common/datasource/conversion/TestSqlDriver.jvm.kt
+++ b/common/datasource/conversion/src/jvmTest/kotlin/com/oztechan/ccc/common/datasource/conversion/TestSqlDriver.jvm.kt
@@ -1,0 +1,9 @@
+package com.oztechan.ccc.common.datasource.conversion
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.oztechan.ccc.common.core.database.sql.CurrencyConverterCalculatorDatabase
+
+internal actual fun createTestSqlDriver(): SqlDriver =
+    JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        .also { CurrencyConverterCalculatorDatabase.Schema.create(it) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ kotlinXDateTime = "0.8.0-0.6.x-compat"
 coroutines = "1.11.0"
 billing = "7.1.1"
 leakCanary = "2.14"
-sqlDelight = "1.5.5"
+sqlDelight = "2.3.2"
 lifecycle = "2.10.0"
 mokoResources = "0.27.0"
 buildKonfig = "0.22.0"
@@ -61,7 +61,7 @@ common-kotlinXDateTime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", ve
 common-ktorJson = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 common-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 common-coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
-common-sqlDelightCoroutinesExt = { module = "com.squareup.sqldelight:coroutines-extensions", version.ref = "sqlDelight" }
+common-sqlDelightCoroutinesExt = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqlDelight" }
 common-mokoResources = { module = "dev.icerock.moko:resources", version.ref = "mokoResources" }
 common-kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 common-detektFormatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
@@ -87,7 +87,7 @@ android-firebasePer = { module = "com.google.firebase:firebase-perf" }
 android-lifecycleViewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 android-lifecycleRuntime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
 android-ktor = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
-android-sqlliteDriver = { module = "com.squareup.sqldelight:android-driver", version.ref = "sqlDelight" }
+android-sqlliteDriver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqlDelight" }
 android-leakCanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakCanary" }
 android-splashScreen = { module = "androidx.core:core-splashscreen", version.ref = "splashScreen" }
 android-rootBeer = { module = "com.scottyab:rootbeer-lib", version.ref = "rootBeer" }
@@ -105,14 +105,14 @@ android-huawei-huaweiOsm = { module = "com.huawei.hms:ads-omsdk", version.ref = 
 
 # IOS
 ios-ktor = { module = "io.ktor:ktor-client-ios", version.ref = "ktor" }
-ios-sqlliteDriver = { module = "com.squareup.sqldelight:native-driver", version.ref = "sqlDelight" }
+ios-sqlliteDriver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqlDelight" }
 
 # JVM
 jvm-test = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 jvm-koinTest = { module = "io.insert-koin:koin-test", version.ref = "koinCore" }
 jvm-ktor = { module = "io.ktor:ktor-client-apache", version.ref = "ktor" }
 jvm-koinKtor = { module = "io.insert-koin:koin-ktor", version.ref = "koinKtor" }
-jvm-sqlliteDriver = { module = "com.squareup.sqldelight:sqlite-driver", version.ref = "sqlDelight" }
+jvm-sqlliteDriver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqlDelight" }
 
 # CLIENT
 client-ktorLogging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
@@ -144,7 +144,7 @@ buildKonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildKonfig"
 firebaseCrashlyticsPlugin = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }
 googleServices = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 firebasePerPlugin = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerPlugin" }
-sqlDelight = { id = "com.squareup.sqldelight", version.ref = "sqlDelight" }
+sqlDelight = { id = "app.cash.sqldelight", version.ref = "sqlDelight" }
 mokoResources = { id = "dev.icerock.mobile.multiplatform-resources", version.ref = "mokoResources" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }


### PR DESCRIPTION
Migrates SQLDelight off the 1.5.5 Gradle plugin, whose shaded pre-1.10 coroutines classes shadow the real `kotlinx-coroutines-core-jvm` and break the build under AGP 9.x.

- `libs.versions.toml`: `sqlDelight` 1.5.5 -> 2.3.2; the plugin id and all four driver/extension artifacts move from `com.squareup.sqldelight` to `app.cash.sqldelight`.
- `common-core-database.gradle.kts`: rewritten to the 2.x `sqldelight { linkSqlite.set(..); databases { create(..) } }` DSL with `srcDirs`.
- Android/iOS/JVM Koin driver modules, `BaseDBDataSource`, and the three datasource tests moved to `app.cash.sqldelight.*`; the 2.x `Query` constructor takes an array instead of a `MutableList`.
- Explicit `: Unit` return types on the `dbQuery {}` overrides whose inference changed in 2.x.

### Test rework

2.x generates **final** query classes, which Mokkery cannot mock (it subclasses at compile time, so there is no Kotlin/Native escape hatch). `SqlDriver.executeQuery` also changed to return `QueryResult<R>`. The three datasource tests are therefore rewritten to run against a real in-memory database instead of mocking `SqlDriver`/`*Queries`:

- New `createTestSqlDriver()` expect/actual per module — `JdbcSqliteDriver(IN_MEMORY)` on the JVM/Android host, `inMemoryDriver(Schema)` on iOS.
- Tests now assert behaviour (insert then read back, state transitions, deletes) rather than verifying that a mock was called.
- iOS test binaries link the system sqlite explicitly; sqldelight's `linkSqlite` only covers `:common:core:database`.

### Verification

Run locally: `detektAll` clean, `check` green on all four touched modules, and the 19 datasource tests pass on both the JVM/Android host and `iosSimulatorArm64`. The `.sq` schema and `.sqm` migrations carry over unchanged.

Resolves Oztechan/CCC#4877